### PR TITLE
Remove bottom border under pages open in sidebar

### DIFF
--- a/zenith.css
+++ b/zenith.css
@@ -223,6 +223,12 @@ textarea, a {
     outline: none !important;
 }
 
+/* fix bottom border under pages open in sidebar */
+/* works in Chrome */
+#roam-right-sidebar-content > div:not(:last-child) {
+    border-bottom: none !important;
+}
+
 #roam-right-sidebar-content {
     visibility: visible;
     display: flex;


### PR DESCRIPTION
Removing the bottom border under pages open in sidebar. Works with Chrome.