### PR TITLE
fix(sidebar-icon): remove `display:block;` to make icons align center again

### DIFF
--- a/cosmonaut.css
+++ b/cosmonaut.css
@@ -275,9 +275,6 @@ textarea, a {
     text-align: center;
     
 }
-#roam-right-sidebar-content > div > .flex-h-box > .bp3-button:first-child, #roam-right-sidebar-content .flex-h-box > .bp3-button:last-child {
-    display: block;
-}
 
 #roam-right-sidebar-content > div .bp3-icon-plus ~ .bp3-button, #roam-right-sidebar-content > div .bp3-icon-plus ~ .bp3-popover-wrapper {
     display: none;

--- a/yggdrasil.css
+++ b/yggdrasil.css
@@ -275,9 +275,6 @@ textarea, a {
     text-align: center;
     
 }
-#roam-right-sidebar-content > div > .flex-h-box > .bp3-button:first-child, #roam-right-sidebar-content .flex-h-box > .bp3-button:last-child {
-    display: block;
-}
 
 #roam-right-sidebar-content > div .bp3-icon-plus ~ .bp3-button, #roam-right-sidebar-content > div .bp3-icon-plus ~ .bp3-popover-wrapper {
     display: none;

--- a/zenith.css
+++ b/zenith.css
@@ -272,9 +272,6 @@ textarea, a {
     text-align: center;
     
 }
-#roam-right-sidebar-content > div > .flex-h-box > .bp3-button:first-child, #roam-right-sidebar-content .flex-h-box > .bp3-button:last-child {
-    display: block;
-}
 
 #roam-right-sidebar-content > div .bp3-icon-plus ~ .bp3-button, #roam-right-sidebar-content > div .bp3-icon-plus ~ .bp3-popover-wrapper {
     display: none;


### PR DESCRIPTION
The code shown below will lead to icon not aligning in center vertically:

https://github.com/azlen/roam-themes/blob/b4e92592e9c6b28cfcd8785e4854817a5bcb4faa/zenith.css#L275-L277

![image](https://user-images.githubusercontent.com/16451516/83901814-ef957c00-a78d-11ea-94aa-36fabf0f814b.png)

Just simply remove the code, icons will be aligned again:

![image](https://user-images.githubusercontent.com/16451516/83902119-6894d380-a78e-11ea-9b72-1d5d9c9b5271.png)
