### PR TITLE
Show block aliases as internal links

### DIFF
--- a/core.css
+++ b/core.css
@@ -76,6 +76,11 @@ textarea, a {
     font-weight: bold;
 }
 
+.rm-alias-block, .rm-alias-block:hover {
+    color: rgb(var(--color-primary)) !important;
+    font-weight: bold;
+}
+
 .rm-page-ref, .rm-alias-page, .rm-alias-page:hover {
     color: rgb(var(--color-primary)) !important;
     font-weight: bold;


### PR DESCRIPTION
Hi,

This is a proposal for signifying block aliases as internal links!

Right now, they look like this:
![image](https://user-images.githubusercontent.com/7115141/85943497-61de2400-b928-11ea-8a75-5d8f42f9d542.png)

After: 
![image](https://user-images.githubusercontent.com/7115141/85943485-53900800-b928-11ea-800d-d7abec2070cb.png)


It gets annoying when I have to switch themes while reading, or hover on the text to see if there are any block aliases I'm missing. I think it makes sense to have this in the primary colour, since it's an internal link - and it doesn't mess with the tagged pages, since the `[[ ]]` are missing.

Perhaps the bold isn't necessary here, but that's up to you, I can customize my defaults in my `roam/css` :)
