### PR TITLE
Updates for Sizing Issues on Mobile and Desktop

### DIFF
--- a/core.css
+++ b/core.css
@@ -1670,3 +1670,65 @@ padding-right: 10px!important;
 .rm-resize-handle:hover, .rm-resize-handle:focus {
     background-color: #66666640;
 }
+
+
+/* FIXING new sizing issues */
+.roam-body .roam-app .roam-main {
+    margin: 0 !important;
+}
+
+.rm-find-or-create-wrapper {
+    flex: 0 1 30px !important;
+}
+
+#find-or-create-input {
+    padding: 0;
+}
+
+#find-or-create-input:focus {
+    padding: 20px;
+}
+
+.bp3-icon-calendar {
+    margin-left: 0 !important;
+}
+
+.rm-topbar {
+    border-radius: 0 0 8px 0;
+    justify-content: space-evenly;
+}
+
+.rm-files-dropzone {
+    z-index: 9999;
+}
+
+.rm-topbar__left-spacer,
+.rm-topbar__spacer-sm {
+    display: none;
+}
+
+@media only screen and (min-width: 768px) {
+    .roam-body .roam-app .roam-main {
+        max-width: 716px !important;
+    }
+
+    .rm-topbar {
+        width: 250px;
+        padding-left: 55px;
+    }
+
+    .rm-sidebar-window {
+        margin: 0;
+    }
+}
+
+@media only screen and (max-width: 767px) {
+    .roam-body .roam-app .roam-main {
+        max-width: 97vw !important;
+    }
+
+    .rm-topbar {
+        width: 200px;
+        padding-left: 20px;
+    }
+}

--- a/cosmonaut.css
+++ b/cosmonaut.css
@@ -59,3 +59,7 @@ span.cm-link { color: #845dc4 !important; }
 span.cm-error { color: #F41000 !important; }
 .CodeMirror-activeline-background { background: #1C005A !important; }
 .CodeMirror-matchingbracket { outline:1px solid grey !important; color:white !important; }
+
+.rm-topbar {
+  background: black;
+}

--- a/yggdrasil.css
+++ b/yggdrasil.css
@@ -56,3 +56,8 @@
 canvas[data-id="layer2-node"] {
     filter: invert(1) hue-rotate(170deg) saturate(2.5);
 }
+
+.rm-topbar {
+  background: #f5f1e2;
+}
+

--- a/zenith.css
+++ b/zenith.css
@@ -32,3 +32,7 @@
 canvas[data-id="layer2-node"] {	
     filter: invert(1) hue-rotate(110deg) saturate(2.5);	
 }
+
+.rm-topbar {
+  background: #eeeeee;
+}


### PR DESCRIPTION
Updated the top bar, right sidebar, and main page css to scale better with the new Roam styling changes. 

Cosmonaut
<img width="1388" alt="Screen Shot 2021-02-28 at 10 55 59" src="https://user-images.githubusercontent.com/5273539/109430444-60349680-79b6-11eb-9042-d694df80ca32.png">

Yggdrasil
<img width="1417" alt="Screen Shot 2021-02-28 at 10 56 23" src="https://user-images.githubusercontent.com/5273539/109430455-6cb8ef00-79b6-11eb-8083-217a341ce2a5.png">

Zenith
<img width="1429" alt="Screen Shot 2021-02-28 at 10 56 12" src="https://user-images.githubusercontent.com/5273539/109430466-70e50c80-79b6-11eb-940a-326612822e26.png">

The updates are currently hosted at the below URL's if you want to test them. 

`https://kylenoble.github.io/roam-themes/cosmonaut.css`

`https://kylenoble.github.io/roam-themes/yggdrasil.css`

`https://kylenoble.github.io/roam-themes/zenith.css`


